### PR TITLE
Support Basic Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ Schema are written in [TOML](https://toml.io/), like so:
 
 ```toml
 # key = "validators"
-name = "required,min=1,max=128"
-age = "required,number,min=1,max=150"
+name = "string,required,min=1,max=128"
+age = "number,required,int,min=1,max=150"
 ecash = "number,required,min=0,max=150000"
-is_cool = "required"
+is_cool = "boolean,required"
 
 # A nested map can be added with [key]
 [location]
-address1 = "required"
-address2 = "required"
+address1 = "string,required"
+address2 = "string,required"
 
 # A slice is added with [[key]]
 
 [[ships]]
-id = "required,uuid"
-make = "oneof=x-wing y-wing a-wing millenium falcon tie-fighter"
+id = "string,required,uuid"
+make = "string,oneof=x-wing y-wing a-wing millenium falcon tie-fighter"
 ```
 
 
@@ -36,25 +36,34 @@ make = "oneof=x-wing y-wing a-wing millenium falcon tie-fighter"
 To validate data against your schema and constraints:
 
 ```go
-dogShelter := LoadSchema(dogShelterSchema)
-err := dogShelter.Validate(myData)
+import (
+    "github.com/Phamiliarize/toml-schema"
+    "github.com/go-playground/validator/v10"
+)
+
+// Use any v10 instance of a go-playground/validator
+// This allows you to extend the potential validators
+v := schema.NewValidator(validator.New())
+err := v.LoadSchema("mySchema", `test = "string,required"`)
+if err != nil {
+    panic(err)
+}
+
+// Returns a map[string]validation.ValidationErrors
+err := v.ValidateSchema("mySchema", myData)
 if err != nil {
     panic(err)
 }
 ```
 
 
-## Supported Types & Constraints
-`toml-schema` bases it's typing with [JSON](https://www.w3schools.com/js/js_json_datatypes.asp) and [Lua](https://www.lua.org/pil/2.html) in mind; this covers the majority of cases.
+## Basic Types & Constraints
+The supported constraints/validations are basically inline with [go-playground/validator](https://github.com/go-playground/validator?tab=readme-ov-file#baked-in-validations) *but* since the end usecase is for [JSON](https://www.w3schools.com/js/js_json_datatypes.asp) and [Lua](https://www.lua.org/pil/2.html) we require a "type constraint" on all fields.
 
+Every field **must start with a basic type**. The basic types supported are:
 
-| Type | GoLang Type |
-| ---- | ---- |
-| `string` | `string` |
-| `number` | `float64` |
-| `boolean` | `bool` |
-| `array` | `[]interface{}` |
-| `object` | `map[string]interface{}` |
-| `nil` | `nil` |
-
-The supported constraints/validations are basically inline with that types offerings for [go-playground/validator](https://github.com/go-playground/validator?tab=readme-ov-file#baked-in-validations).
+| Type | GoLang Type | Validators | 
+| ---- | ---- | ---- |
+| string | `string` | `string` |
+| number | `float64` or `int` | `number`|
+| boolean | `bool` | `boolean` |

--- a/schema_test.go
+++ b/schema_test.go
@@ -15,21 +15,21 @@ func TestValidator_LoadSchema(t *testing.T) {
 	loadTestSchema(&tomlSchema, "character")
 
 	control := map[string]interface{}{
-		"age":             "required,number,min=1,max=1500",
+		"age":             "number,required,min=1,max=1500",
 		"credits":         "number,required,min=0,max=150000",
-		"force_sensitive": "required",
+		"force_sensitive": "boolean,required",
 		"location": map[string]interface{}{
-			"address1": "required",
-			"address2": "required",
+			"address1": "string,required",
+			"address2": "string,required",
 		},
-		"name": "required,min=1,max=128",
+		"name": "string,required,min=1,max=128",
 		"ships": map[string]interface{}{
-			"id":   "required,uuid",
-			"make": "oneof=x-wing y-wing a-wing millenium falcon tie-fighter",
+			"id":   "string,required,uuid",
+			"make": "string,oneof=x-wing y-wing a-wing millenium falcon tie-fighter",
 			"data": map[string]interface{}{
-				"id": "required,uuid",
+				"id": "string,required,uuid",
 				"data": map[string]interface{}{
-					"id": "required,uuid",
+					"id": "string,required,uuid",
 				},
 			},
 		},
@@ -44,6 +44,14 @@ func TestValidator_LoadSchema_BadSchema(t *testing.T) {
 	err := tomlSchema.LoadSchema("test", `
 	test =
 	`)
+	if err == nil {
+		t.Errorf("expected bad schema load to raise an error")
+	}
+}
+
+func TestValidator_LoadSchema_MissingBasicType(t *testing.T) {
+	tomlSchema := NewValidator(validate.New())
+	err := tomlSchema.LoadSchema("test", `test = "required,min=1"`)
 	if err == nil {
 		t.Errorf("expected bad schema load to raise an error")
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -61,6 +61,10 @@ func TestValidator_ValidateSchema(t *testing.T) {
 	tomlSchema := NewValidator(validate.New())
 	loadTestSchema(&tomlSchema, "basic")
 	loadTestSchema(&tomlSchema, "character")
+	_ = tomlSchema.LoadSchema("basicType", `test1 = "string,required"
+test2 = "number,required"
+test3 = "boolean,required"
+`)
 	data := loadTestData()
 
 	cases := []struct {
@@ -87,6 +91,11 @@ func TestValidator_ValidateSchema(t *testing.T) {
 			schemaName:  "basic",
 			data:        data["basic"].(map[string]interface{})["3"].(map[string]interface{}),
 			expectedErr: 4,
+		},
+		{
+			schemaName:  "basicType",
+			data:        data["basicType"].(map[string]interface{})["1"].(map[string]interface{}),
+			expectedErr: 3,
 		},
 	}
 

--- a/testdata/basic.toml
+++ b/testdata/basic.toml
@@ -1,5 +1,5 @@
-name = "required,min=1,max=128"
-email = "required,email"
-age = "required,number,min=1,max=150"
+name = "string,required,min=1,max=128"
+email = "string,required,email"
+age = "number,required,number,min=1,max=150"
 ecash = "number,required"
 

--- a/testdata/character.toml
+++ b/testdata/character.toml
@@ -1,18 +1,18 @@
-name = "required,min=1,max=128"
-age = "required,number,min=1,max=1500"
+name = "string,required,min=1,max=128"
+age = "number,required,min=1,max=1500"
 credits = "number,required,min=0,max=150000"
-force_sensitive = "required"
+force_sensitive = "boolean,required"
 
 [location]
-address1 = "required"
-address2 = "required"
+address1 = "string,required"
+address2 = "string,required"
 
 [[ships]]
-id = "required,uuid"
-make = "oneof=x-wing y-wing a-wing millenium falcon tie-fighter"
+id = "string,required,uuid"
+make = "string,oneof=x-wing y-wing a-wing millenium falcon tie-fighter"
 
 [[ships.data]]
-id = "required,uuid"
+id = "string,required,uuid"
 
 [[ships.data.data]]
-id = "required,uuid"
+id = "string,required,uuid"

--- a/testdata/data.json
+++ b/testdata/data.json
@@ -14,6 +14,13 @@
             "ecash": "six"
         }
     },
+    "basicType": {
+        "1": {
+            "test1": 2,
+            "test2": true,
+            "test3": "true"
+        }
+    },
     "character": {
         "1": {
             "name": "Luke Skywalker",


### PR DESCRIPTION
Added support (or requirement, really) for a basic type to be defined on all fields; this is also necessary when using `map[string]interface{}` values